### PR TITLE
Add IID preprocessing pipeline for market data

### DIFF
--- a/configs/default_config.yaml
+++ b/configs/default_config.yaml
@@ -45,6 +45,21 @@ preprocessing:
   remove_outliers: false
   outlier_std_threshold: 3.0
   fill_missing_strategy: ffill
+  make_iid_data: true
+  iid:
+    method: log_return
+    volume_method: pct_change
+    other_method: diff
+    price_columns:
+      - open
+      - high
+      - low
+      - close
+    volume_columns:
+      - volume
+    epsilon: 1.0e-08
+    dropna: true
+    fillna_value: 0.0
   min_data_points: 1000
   train_test_split_ratio: 0.8
   validation_set_ratio: 0.1

--- a/configs/example_config.yaml
+++ b/configs/example_config.yaml
@@ -45,6 +45,21 @@ preprocessing:
   remove_outliers: false
   outlier_std_threshold: 3.0
   fill_missing_strategy: ffill
+  make_iid_data: true
+  iid:
+    method: log_return
+    volume_method: pct_change
+    other_method: diff
+    price_columns:
+      - open
+      - high
+      - low
+      - close
+    volume_columns:
+      - volume
+    epsilon: 1.0e-08
+    dropna: true
+    fillna_value: 0.0
   min_data_points: 1000
   train_test_split_ratio: 0.8
   validation_set_ratio: 0.1

--- a/src/data/managers/data_manager.py
+++ b/src/data/managers/data_manager.py
@@ -184,7 +184,13 @@ class MarketDataManager:
             
             # ประมวลผลข้อมูลด้วย DataProcessor
             self.data = self.data_processor.preprocess_data(self.raw_data)
-            
+
+            # ถ้ามีการตัดข้อมูลเพื่อให้เป็น I.I.D. ให้จัดแนว raw_data ให้ตรงกัน
+            if self.data_processor.valid_index is not None:
+                valid_index = self.data_processor.valid_index
+                if len(valid_index) != len(self.raw_data):
+                    self.raw_data = self.raw_data.iloc[list(valid_index)].reset_index(drop=True)
+
             # เก็บสถิติสำหรับการแปลงกลับ
             self.stats = self.data_processor.stats
             


### PR DESCRIPTION
## Summary
- add configurable IID transformation support to the data processor to convert time-series into IID-friendly features
- align the market data manager's raw data with the processed IID index and surface associated metadata
- enable IID preprocessing defaults in the configuration files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca91da7e80832faf0f4df4831e8b44