### PR TITLE
Add compatibility shim for src.utils.config imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ logs/
 .env
 
 # ไฟล์การตั้งค่าส่วนตัว
-src/utils/config.py
 configs/api_keys.json
 configs/credentials.json
 configs/personal_settings.json

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,0 +1,18 @@
+"""Compatibility layer for configuration utilities.
+
+This module re-exports the configuration helpers from
+``src.utils.config_manager`` so that existing imports that reference
+``src.utils.config`` continue to function.
+"""
+
+from .config_manager import ConfigManager, get_config
+
+set_cuda_env = ConfigManager.set_cuda_env
+update_config_from_args = ConfigManager.update_config_from_args
+
+__all__ = [
+    "ConfigManager",
+    "get_config",
+    "set_cuda_env",
+    "update_config_from_args",
+]


### PR DESCRIPTION
## Summary
- add `src/utils/config.py` to re-export configuration helpers from `config_manager`
- update `.gitignore` so the compatibility module is tracked in version control

## Testing
- `python -m src.cli.main data download --symbol BTCUSDT --timeframes 1h --start 2024-01-01 --end 2024-01-02 --output /tmp --format csv` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68cabd63c138832f918dfab78ab519a5