### PR TITLE
Expose CUDA helper in config manager

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -5,10 +5,12 @@ This module re-exports the configuration helpers from
 ``src.utils.config`` continue to function.
 """
 
-from .config_manager import ConfigManager, get_config
-
-set_cuda_env = ConfigManager.set_cuda_env
-update_config_from_args = ConfigManager.update_config_from_args
+from .config_manager import (
+    ConfigManager,
+    get_config,
+    set_cuda_env,
+    update_config_from_args,
+)
 
 __all__ = [
     "ConfigManager",


### PR DESCRIPTION
## Summary
- add module level helpers in `config_manager` including `set_cuda_env`
- update the compatibility re-exports in `src.utils.config`
- document the configuration utilities and improve argument mapping helper

## Testing
- python -m src.cli.main --help *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68cac4f7ac2c832faeaac72edf437351